### PR TITLE
Add/controller action description parsing from source code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       kaminari
       rails (~> 5.0)
       slim-rails
+      yard
 
 GEM
   remote: https://rubygems.org/
@@ -309,7 +310,6 @@ DEPENDENCIES
   sqlite3
   travis
   travis-lint
-  yard
 
 BUNDLED WITH
    1.16.6

--- a/app/models/authz/controller_action.rb
+++ b/app/models/authz/controller_action.rb
@@ -76,6 +76,12 @@ module Authz
         pending << route unless ca
       end
 
+      pending.each do |pair|
+        c_name, a_name = pair[:controller], pair[:action]
+        description = Authz.controller_metadata_service.get_controller_action_description(c_name, a_name)
+        pair[:description] = description
+      end
+
       pending
     end
 
@@ -99,6 +105,12 @@ module Authz
     # @return [String] concatenation of controller#action-id
     def to_s
       "#{controller}##{action}-#{id}"
+    end
+
+    # @return [String] description of a controller action, parsed through the
+    #                  controller_metadata_service
+    def description
+      Authz.controller_metadata_service.get_controller_action_description(self.controller, self.action)
     end
 
     private

--- a/app/views/authz/controller_actions/_controller_action.html.slim
+++ b/app/views/authz/controller_actions/_controller_action.html.slim
@@ -2,6 +2,7 @@ tr.is-clickable[data-url="#{controller_action_path(controller_action)}"]
   td = controller_action.id
   td = controller_action.controller
   td = controller_action.action
+  td = controller_action.description
 
   - show_ca_path = controller_action_path(controller_action)
   - if authorized_path? show_ca_path, skip_scoping: true

--- a/app/views/authz/controller_actions/_table.html.slim
+++ b/app/views/authz/controller_actions/_table.html.slim
@@ -7,6 +7,7 @@
         th ID
         th Controller Name
         th Action Name
+        th Description
         th
     tbody
       = render controller_actions

--- a/app/views/authz/pending_controller_actions/index.html.slim
+++ b/app/views/authz/pending_controller_actions/index.html.slim
@@ -19,8 +19,10 @@ section.section
             tr
               th Controller Name
               th Action Name
+              th Action Description
           tbody
             - @pending_controller_actions.each do |controller_action|
               tr
                 td = controller_action[:controller]
                 td = controller_action[:action]
+                td = controller_action[:description]

--- a/authz.gemspec
+++ b/authz.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'slim-rails'
+  s.add_dependency 'yard'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "devise"
@@ -49,5 +50,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'travis'
   s.add_development_dependency 'travis-lint'
   s.add_development_dependency 'rack-mini-profiler'
-  s.add_development_dependency 'yard'
 end

--- a/lib/authz.rb
+++ b/lib/authz.rb
@@ -1,5 +1,6 @@
 require 'authz/engine'
 require 'authz/cache'
+require 'authz/yard_controller_metadata_service'
 require 'authz/models/rolable'
 require 'authz/controllers/scoping_manager'
 require 'authz/controllers/authorization_manager'
@@ -9,6 +10,7 @@ require 'slim-rails'
 require 'kaminari'
 require 'jquery-rails'
 require 'font-awesome-rails'
+require 'yard'
 
 
 # Stores the configuration parameters of the library
@@ -53,6 +55,9 @@ module Authz
   mattr_reader :cache
   # The attribute that points to the cache module
   @@cache = Authz::Cache
+
+  mattr_reader :controller_metadata_service
+  @@controller_metadata_service = Authz::YardControllerMetadataService.new
 
   # Allows the configuration of the gem using
   # block syntax

--- a/lib/authz/yard_controller_metadata_service.rb
+++ b/lib/authz/yard_controller_metadata_service.rb
@@ -8,22 +8,27 @@ module Authz
     end
 
     def get_controller_action_description(controller_name, action_name)
-      controller_filename = "#{controller_name}_controller.rb"
-      controller_path = Rails.root.join(
-        "app",
-        "controllers",
-        controller_filename
+      YARD.parse(controller_filename(controller_name))
+
+      YARD::Registry.at(
+        action_symbol(controller_name, action_name)
+      )&.tag(:authz_description)&.text
+    end
+
+    private
+
+    def controller_filename(controller_name)
+      Rails.root.join(
+        'app', 'controllers', "#{controller_name}_controller.rb"
       ).to_s
-      action_path = controller_name
-        .split("/")
+    end
+
+    def action_symbol(controller_name, action_name)
+      controller_name
+        .split('/')
         .map(&:camelize)
-        .join("::")
+        .join('::')
         .concat("Controller\##{action_name}")
-
-      YARD::parse(controller_path)
-
-      method_code_object = YARD::Registry.at(action_path)
-      method_code_object&.tag(:authz_description)&.text
     end
   end
 end

--- a/lib/authz/yard_controller_metadata_service.rb
+++ b/lib/authz/yard_controller_metadata_service.rb
@@ -1,6 +1,11 @@
 module Authz
   class YardControllerMetadataService
+
+
     def initialize
+      @descriptions = {}
+
+      # Register Authz tag so that YARD can parse it
       YARD::Tags::Library.define_tag(
         "Authz controller action description",
         :authz_description
@@ -8,14 +13,18 @@ module Authz
     end
 
     def get_controller_action_description(controller_name, action_name)
-      YARD.parse(controller_filename(controller_name))
+      descriptions.fetch(action_symbol(controller_name, action_name)) do |as|
+        YARD.parse(controller_filename(controller_name))
 
-      YARD::Registry.at(
-        action_symbol(controller_name, action_name)
-      )&.tag(:authz_description)&.text
+        description = YARD::Registry.at(as)&.tag(:authz_description)&.text
+
+        descriptions[as] = description
+      end
     end
 
     private
+
+    attr_reader :descriptions
 
     def controller_filename(controller_name)
       Rails.root.join(

--- a/lib/authz/yard_controller_metadata_service.rb
+++ b/lib/authz/yard_controller_metadata_service.rb
@@ -1,0 +1,29 @@
+module Authz
+  class YardControllerMetadataService
+    def initialize
+      YARD::Tags::Library.define_tag(
+        "Authz controller action description",
+        :authz_description
+      )
+    end
+
+    def get_controller_action_description(controller_name, action_name)
+      controller_filename = "#{controller_name}_controller.rb"
+      controller_path = Rails.root.join(
+        "app",
+        "controllers",
+        controller_filename
+      ).to_s
+      action_path = controller_name
+        .split("/")
+        .map(&:camelize)
+        .join("::")
+        .concat("Controller\##{action_name}")
+
+      YARD::parse(controller_path)
+
+      method_code_object = YARD::Registry.at(action_path)
+      method_code_object&.tag(:authz_description)&.text
+    end
+  end
+end

--- a/spec/dummy/app/controllers/cities_controller.rb
+++ b/spec/dummy/app/controllers/cities_controller.rb
@@ -8,6 +8,8 @@ class CitiesController < ApplicationController
   end
 
   # GET /cities/new
+  #
+  # @authz.description Renders the form to create a new city
   def new
     authorize skip_scoping: true
     @city = City.new


### PR DESCRIPTION
Get the description of controller actions from the code - using YARD `@authz.description` tag - and display this in the UI to help users to understand what an action does.

This looks like this in practice:


![screen shot 2019-03-05 at 14 09 33](https://user-images.githubusercontent.com/700245/53778386-a33b0b00-3f50-11e9-8741-5ff6fd3cbd02.png)
